### PR TITLE
HW #01

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -6,6 +6,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
@@ -33,6 +34,7 @@ class PaymentExternalSystemAdapterImpl(
     private val requestAverageProcessingTime = properties.averageProcessingTime
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
+    private val rate_limiter = SlidingWindowRateLimiter(10, java.time.Duration.ofMillis(1000));
 
     private val client = OkHttpClient.Builder().build()
 
@@ -48,6 +50,8 @@ class PaymentExternalSystemAdapterImpl(
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
+
+        rate_limiter.tickBlocking()
 
         try {
             val request = Request.Builder().run {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -34,7 +34,7 @@ class PaymentExternalSystemAdapterImpl(
     private val requestAverageProcessingTime = properties.averageProcessingTime
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
-    private val rate_limiter = SlidingWindowRateLimiter(10, java.time.Duration.ofMillis(1000));
+    private val rate_limiter = SlidingWindowRateLimiter(rateLimitPerSec * 1L, java.time.Duration.ofMillis(1000));
 
     private val client = OkHttpClient.Builder().build()
 


### PR DESCRIPTION
## Настройки аккаунта:
1. Число одновременно исполняющихся задач - 30
2. Максимальное число проксируемых запросов в секунду - 10.
3. Среднее время исполнения запроса - 1 секунда.
## Условия теста:
1. Число запросов в секунду - 11.

## Результаты до:

### Число успешных  запросов
<img width="1501" height="645" alt="image" src="https://github.com/user-attachments/assets/596dc081-af8a-4acc-a1fd-ff3d79a73028" />

### Выручка
<img width="1501" height="645" alt="image" src="https://github.com/user-attachments/assets/9164ffe7-ecd0-4b5b-9eb6-1f866f70c53a" />

## Решение
Заметили, что число запросов, которое к нам приходит меньше числа запросов, которые мы можем проксировать, поэтому решили добавить rate limiter. Это позволит исполнять каждую секунду столько запросов, сколько позволяет система

## Результаты после:

### Число успешных запросов
<img width="1500" height="658" alt="image" src="https://github.com/user-attachments/assets/8cd483c1-9a03-4c1b-a39f-805d6af6f41b" />

### Выручка
<img width="1500" height="618" alt="image" src="https://github.com/user-attachments/assets/0ebc034b-b5fd-4caf-9d3d-8eb977aaa4d9" />
