### PR TITLE
HW #02

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,36 @@
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-bulkhead</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-cache</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-timelimiter</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -39,7 +39,7 @@ class PaymentExternalSystemAdapterImpl(
     private val parallelRequests = properties.parallelRequests
     private val rate_limiter = SlidingWindowRateLimiter(rateLimitPerSec * 1L, Duration.ofMillis(1000))
     private val bulkhead = Bulkhead.of("http-client", BulkheadConfig.custom()
-        .maxConcurrentCalls(5)
+        .maxConcurrentCalls(parallelRequests)
         .maxWaitDuration(Duration.ofMillis(60_000))
         .build())
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-3
+payment.accounts=acc-5
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
## Настройки аккаунта:
1. Число одновременно исполняющихся задач - 5.
2. Максимальное число проксируемых запросов в секунду - 3.
3. Среднее время исполнения запроса - 4.9 секунды.

## Условия теста:
1. Число запросов в секунду - 2.
2. Максимальное время исполнения запроса - 60 секунд.

## Результаты до
<img width="1534" height="742" alt="image" src="https://github.com/user-attachments/assets/097c1fb2-703e-4508-81cb-cf28fecc2d49" />

## Решение
Как видно из условий в данном случае rate limiter не поможет, так как число проксируемых запросов больше, чем приходящих. Однако теперь запросы исполняются практически 5 секунд, а значит уже на 3 секунде, параллельных будет больше, чем позволяет аккаунт. Чтобы этого избежать настроим семафор, который будет допускать максимум 5 параллельных запросов, а также каждый новый будет ждать небольше 60 секунд (время ожидания клиента)

## Результаты после

### Число успешных тестов
![photo_2025-09-26_18-48-22](https://github.com/user-attachments/assets/813ebc52-7f63-4148-a1e5-a0165c96f3a6)

### Выручка
![photo_2025-09-26_18-48-31](https://github.com/user-attachments/assets/6fa417d9-0777-4a1e-b1f3-73aa4917cbc1)

