### PR TITLE
HW #06

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -14,6 +14,7 @@ import ru.quipy.payments.logic.OrderPayer
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.math.log
 
 @RestController
 class APIController {
@@ -37,14 +38,14 @@ class APIController {
 
     private val rateLimiter =
             TokenBucketRateLimiter(
-                rate = 11,
-                bucketMaxCapacity = 132,
+                rate = 10,
+                bucketMaxCapacity = 275,
                 window = 1,
                 timeUnit = TimeUnit.SECONDS
             )
 
     fun dropRequest(): ResponseEntity<PaymentSubmissionDto> {
-        val now = System.currentTimeMillis() + 2500
+        val now = System.currentTimeMillis() + 700
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", now.toString()).build()
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -17,6 +17,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
+import kotlin.math.log
 
 
 // Advice: always treat time as a Duration
@@ -43,7 +44,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rate_limiter = SlidingWindowRateLimiter(rateLimitPerSec * 1L, Duration.ofMillis(1000))
     private val bulkhead = Bulkhead.of("http-client", BulkheadConfig.custom()
         .maxConcurrentCalls(parallelRequests)
-        .maxWaitDuration(Duration.ofMillis(30_000))
+        .maxWaitDuration(Duration.ofMillis(1_000_000))
         .build())
 
     private val sent_to_bank: Counter = Counter
@@ -52,6 +53,7 @@ class PaymentExternalSystemAdapterImpl(
         .register(metricRegistry)
 
     private val client = OkHttpClient.Builder().build()
+    private var orderMap = HashMap<UUID, Long>()
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -66,34 +68,24 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
+        for (i in 1 .. 3) {
+            if (bankPayment(transactionId, paymentId, amount, paymentStartedAt)) {
+                return
+            }
+            val deadline: Long = orderMap[paymentId] ?: 0
+            Thread.sleep(deadline)
+            orderMap[paymentId] = deadline + requestAverageProcessingTime.toMillis()
+        }
+    }
+
+    fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long): Boolean{
         try {
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
                 post(emptyBody)
             }.build()
 
-
-            bulkhead.executeCallable {
-                rate_limiter.tickBlocking()
-
-                    sent_to_bank.increment()
-                    client.newCall(request).execute().use { response ->
-                        val body = try {
-                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                        } catch (e: Exception) {
-                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                            ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                        }
-
-                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-
-                        // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                        // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                        }
-                    }
-            }
+            return sendRequest(transactionId, paymentId, request, paymentStartedAt)
         } catch (e: Exception) {
             when (e) {
                 is SocketTimeoutException -> {
@@ -112,6 +104,35 @@ class PaymentExternalSystemAdapterImpl(
                 }
             }
         }
+        return false
+    }
+
+    fun sendRequest(transactionId: UUID, paymentId: UUID, request: Request, paymentStartedAt: Long): Boolean {
+        var result = true
+        bulkhead.executeCallable {
+            rate_limiter.tickBlocking()
+
+            sent_to_bank.increment()
+            client.newCall(request).execute().use { response ->
+                val body = try {
+                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+                }
+
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                }
+
+                result = body.result
+            }
+        }
+        return result
     }
 
     override fun price() = properties.price

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-23
+payment.accounts=acc-8
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
## Настройки аккаунта:
1. Число одновременно исполняющихся задач - 50.
2. Максимальное число проксируемых запросов в секунду - 10.
3. Среднее время исполнения запроса - 0.7 секунда.

## Условия теста:
1. Число запросов в секунду - 7.
2. Максимальное время исполнения запроса - 3.5 секунды.

## До изменений в коде

<img width="1280" height="703" alt="image" src="https://github.com/user-attachments/assets/ba2995a8-9396-423d-b147-af6e501b0de8" />


## Проблемы:
Сначала мы решили посмотреть на график "Response Time", чтобы стало понятно, сколько реально исполняется запрос. Первая идея, которая пришла в голову - это изменить время в заголовке "Retry-After". По графику некоторые запросы исполнялись 1.5 секунды.

<img width="1280" height="703" alt="image" src="https://github.com/user-attachments/assets/e62f6259-eece-4ccf-b386-bc0bb14e9edb" />
Таким образом, решили поставить timeout на исполнение в 2 секунды (3.5 - 1.5 секунды на исполнение). Это не помогло (сейчас даже не понимаю, зачем это было нужно). После этого, мы решили добавить логи, чтобы посмотреть на тело ответа от банка. Мы надеялись увидеть там заголовок "Retry-After", чтобы просто подождать нужное время и послать запрос заново. Заголовки, которые были в ответе.

```
Date: Thu, 30 Oct 2025 19:41:59 GMT
Content-Type: application/json
Transfer-Encoding: chunked
```
Также мы посмотрели по логам причину, по которой запросы не исполняются. Мы увидели сообщение 

```
succeeded: false, message: Temprory error
```


## Идеи, которые мы попробовали 

Первая наша идея давайте каким-то образом идентифицировать приходящие к нам запросы. Если мы сказали на какой-то запрос too_many_requests, а потом он пришёл ещё раз (мы его идентифицировали и поняли что это тот же самый, что уже был) то поставим ему поле retry-after в два раза больше, чем то значение, что ставили до этого

Вторая идея, так как мы не увидели retry-after в запросе, давайте сами будем выбирать время, которое будем ждать перед ретраем к банку. 

Пробовали разные стратегии:
Фиксированное время ожидание
<img width="1280" height="703" alt="image" src="https://github.com/user-attachments/assets/52e8be4a-559d-492d-8c0a-7dcbc3c3d940" />

Увеличение в 2 и 1.5 раза от среднего времени исполнения запроса.
<img width="1280" height="703" alt="image" src="https://github.com/user-attachments/assets/f473e7a0-b6e5-4f07-95b6-8dc83cdfa724" />

Самым лучшим показала себя стратегия - увеличивать время сна на среднее время исполнения запроса.

## Текущая реализация 
Во-первых мы добавили retry. После получения ответа от банка, мы фиксируем результат в переменной. Если предыдущий результат был success, то retry не требуется. В ином случае пытаемся послать запрос заново. Как говорил, Влад, мы пробовали разные стратегии на retry. Лучше всего оказалось после первого запроса, посылать запрос сразу же. Последний retry мы отправляем с задержкой равной среднему времени исполнения запроса (опять же получено экспериментально). Для идентификации запроса мы использовали хеш мапу. Ключ в ней это payment_id.
Вот результаты после добавления retry
![2025-10-31 18 22 59](https://github.com/user-attachments/assets/76c8a216-d7b8-4a78-9e47-caac30c6434d)
![2025-10-31 18 23 03](https://github.com/user-attachments/assets/5c765cfe-e698-4623-8fe9-64c25fb9394a)

