### PR TITLE
HW #09

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-alpine-3.22
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-alpine-3.22 AS build
+FROM maven:3.9.0-eclipse-temurin-19  AS build
 
 WORKDIR /app
 COPY pom.xml .
@@ -6,7 +6,7 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM eclipse-temurin:17-alpine-3.22
+FROM eclipse-temurin:19
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-alpine-3.22. AS build
+FROM openjdk:17-jdk-slim AS build
 
 WORKDIR /app
 COPY pom.xml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim AS build
+FROM eclipse-temurin:17-alpine-3.22 AS build
 
 WORKDIR /app
 COPY pom.xml .

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-cio-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-kotlin</artifactId>
             <version>2.2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,46 @@
         <resilience4jVersion>2.2.0</resilience4jVersion>
         <json-datatype.version>2.9.8</json-datatype.version>
         <caffeine.version>3.1.8</caffeine.version>
+        <ktor.version>3.3.3</ktor.version>
     </properties>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-core-jvm</artifactId>
+            <version>3.3.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-okhttp-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-kotlin</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-okhttp</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-content-negotiation</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-ratelimiter</artifactId>
@@ -166,7 +203,6 @@
 
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -246,6 +282,20 @@
                     <source>17</source>
                     <target>17</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <json-datatype.version>2.9.8</json-datatype.version>
         <caffeine.version>3.1.8</caffeine.version>
         <ktor.version>3.3.3</ktor.version>
+<!--        <httpclient5.version>5.3.1</httpclient5.version>-->
     </properties>
 
 	<dependencies>
@@ -42,6 +43,24 @@
         <dependency>
             <groupId>io.ktor</groupId>
             <artifactId>ktor-client-okhttp-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-apache5-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-jetty-jakarta-jvm</artifactId>
             <version>${ktor.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
 
         <dependency>
             <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-java-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ktor</groupId>
             <artifactId>ktor-client-cio-jvm</artifactId>
             <version>${ktor.version}</version>
         </dependency>

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -38,14 +38,14 @@ class APIController {
 
     private val rateLimiter =
             TokenBucketRateLimiter(
-                rate = 100,
-                bucketMaxCapacity = 275,
+                rate = 1000,
+                bucketMaxCapacity = 100_000,
                 window = 1,
                 timeUnit = TimeUnit.SECONDS
             )
 
     fun dropRequest(): ResponseEntity<PaymentSubmissionDto> {
-        val now = System.currentTimeMillis() + 700
+        val now = System.currentTimeMillis() + 20_000
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", now.toString()).build()
     }
 

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -38,8 +38,8 @@ class APIController {
 
     private val rateLimiter =
             TokenBucketRateLimiter(
-                rate = 1000,
-                bucketMaxCapacity = 1000,
+                rate = 1100,
+                bucketMaxCapacity = 1200,
                 window = 1,
                 timeUnit = TimeUnit.SECONDS
             )

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -39,7 +39,7 @@ class APIController {
     private val rateLimiter =
             TokenBucketRateLimiter(
                 rate = 1000,
-                bucketMaxCapacity = 100_000,
+                bucketMaxCapacity = 1000,
                 window = 1,
                 timeUnit = TimeUnit.SECONDS
             )

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -36,12 +36,6 @@ class APIController {
 
     data class User(val id: UUID, val name: String)
 
-    private val rateLimiter =
-        SlidingWindowRateLimiter(
-                rate = 1300,
-                window = Duration.ofMillis(1_000),
-            )
-
     fun dropRequest(): ResponseEntity<PaymentSubmissionDto> {
         val now = System.currentTimeMillis() + 5_000
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", now.toString()).build()
@@ -81,9 +75,6 @@ class APIController {
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-//        if (!rateLimiter.tick()) {
-//            return dropRequest()
-//        }
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         if (createdAt == -1L) {
             return dropRequest()

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -37,15 +37,13 @@ class APIController {
     data class User(val id: UUID, val name: String)
 
     private val rateLimiter =
-            TokenBucketRateLimiter(
-                rate = 1100,
-                bucketMaxCapacity = 1200,
-                window = 1,
-                timeUnit = TimeUnit.SECONDS
+        SlidingWindowRateLimiter(
+                rate = 1300,
+                window = Duration.ofMillis(1_000),
             )
 
     fun dropRequest(): ResponseEntity<PaymentSubmissionDto> {
-        val now = System.currentTimeMillis() + 20_000
+        val now = System.currentTimeMillis() + 5_000
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", now.toString()).build()
     }
 
@@ -83,9 +81,9 @@ class APIController {
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-        if (!rateLimiter.tick()) {
-            return dropRequest()
-        }
+//        if (!rateLimiter.tick()) {
+//            return dropRequest()
+//        }
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         if (createdAt == -1L) {
             return dropRequest()

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -29,20 +29,20 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        50,
-        50,
+        20,
+        20,
         0L,
         TimeUnit.MILLISECONDS,
-        LinkedBlockingQueue(480),
+        LinkedBlockingQueue(500_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        if (paymentExecutor.queue.size > 270) {
-            return -1
-        }
+//        if (paymentExecutor.queue.size > 200_000) {
+//            return -1
+//        }
         paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -29,8 +29,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        20,
-        20,
+        50,
+        50,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(500_000),
@@ -40,7 +40,7 @@ class OrderPayer {
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        if (paymentExecutor.queue.size > 200_000) {
+        if (paymentExecutor.queue.size > 500_000) {
             return -1
         }
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -35,14 +35,14 @@ class OrderPayer {
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(500_000),
         NamedThreadFactory("payment-submission-executor"),
-        CallerBlockingRejectedExecutionHandler()
+        ThreadPoolExecutor.DiscardOldestPolicy()
     )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-//        if (paymentExecutor.queue.size > 200_000) {
-//            return -1
-//        }
+        if (paymentExecutor.queue.size > 200_000) {
+            return -1
+        }
         paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -29,8 +29,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        50,
-        50,
+        500,
+        500,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(500_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -29,8 +29,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        500,
-        500,
+        50,
+        50,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(500_000),
@@ -40,9 +40,9 @@ class OrderPayer {
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        if (paymentExecutor.queue.size > 500_000) {
-            return -1
-        }
+//        if (paymentExecutor.queue.size > 500_000) {
+//            return -1
+//        }
         paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -29,20 +29,20 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        50,
-        50,
+        10,
+        10,
         0L,
         TimeUnit.MILLISECONDS,
-        LinkedBlockingQueue(500_000),
+        LinkedBlockingQueue(5_000),
         NamedThreadFactory("payment-submission-executor"),
         ThreadPoolExecutor.DiscardOldestPolicy()
     )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-//        if (paymentExecutor.queue.size > 500_000) {
-//            return -1
-//        }
+        if (paymentExecutor.queue.size > 4500) {
+            return -1
+        }
         paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -81,7 +81,7 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     private val connectionPool = ConnectionPool(
-        maxIdleConnections = 50,
+        maxIdleConnections = parallelRequests,
         keepAliveDuration = 13,
         timeUnit = TimeUnit.MINUTES,
     )

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -8,17 +8,28 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.prometheus.metrics.core.metrics.Summary
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import okhttp3.internal.wait
+import okio.IOException
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
+import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
+import java.sql.Time
 import java.time.Duration
 import java.util.*
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 
@@ -63,11 +74,40 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentiles( 0.9, 0.99, 0.999, 0.9999)
         .register(metricRegistry)
 
+    private val dispatcher = Dispatcher().apply {
+        maxRequests = 10_000
+        maxRequestsPerHost = 10_000
+    }
+
+    private val connectionPool = ConnectionPool(
+        maxIdleConnections = 20,
+        keepAliveDuration = 7,
+        timeUnit = TimeUnit.MINUTES,
+    )
+
     private val client = OkHttpClient.Builder()
-        .callTimeout(1350, TimeUnit.MILLISECONDS)
+        .retryOnConnectionFailure(true)
+        .connectTimeout(23_000, TimeUnit.MILLISECONDS)
+        .readTimeout(23_000, TimeUnit.MILLISECONDS)
+        .writeTimeout(23_000, TimeUnit.MILLISECONDS)
+        .callTimeout(23_000, TimeUnit.MILLISECONDS)
+        .connectionPool(connectionPool)
+        .dispatcher(dispatcher)
         .build()
 
+    private val databaseThreadPool = ThreadPoolExecutor(
+        20,
+        50,
+        0L,
+        TimeUnit.MILLISECONDS,
+        LinkedBlockingQueue(500_000),
+        NamedThreadFactory("payment-submission-executor"),
+        CallerBlockingRejectedExecutionHandler()
+    )
+
     private var orderMap = HashMap<UUID, Long>()
+
+
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -76,73 +116,72 @@ class PaymentExternalSystemAdapterImpl(
 
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        paymentESService.update(paymentId) {
-            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+        databaseThreadPool.submit {
+            paymentESService.update(paymentId) {
+                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            }
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        for (i in 1 .. 3) {
-            if (bankPayment(transactionId, paymentId, amount, paymentStartedAt)) {
-                return
-            }
-            val deadline: Long = orderMap[paymentId] ?: 0
-            Thread.sleep(deadline)
-            orderMap[paymentId] = 0
-            repeat_request.increment()
-        }
+        bankPayment(transactionId, paymentId, amount, paymentStartedAt)
     }
 
-    fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long): Boolean{
+    fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long) {
         try {
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
                 post(emptyBody)
             }.build()
 
-            return sendRequest(transactionId, paymentId, request, paymentStartedAt)
+            sendRequest(transactionId, paymentId, request, paymentStartedAt)
         } catch (e: Exception) {
-            when (e) {
-                is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                    }
-                }
-
-                else -> {
-                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
-                }
+            databaseThreadPool.submit {
+                handleError(transactionId, paymentId, e)
             }
         }
-        return false
     }
 
-    fun sendRequest(transactionId: UUID, paymentId: UUID, request: Request, paymentStartedAt: Long): Boolean {
-        var result = true
+    fun sendRequest(transactionId: UUID, paymentId: UUID, request: Request, paymentStartedAt: Long) {
         bulkhead.executeCallable {
             rate_limiter.tickBlocking()
 
             sent_to_bank.increment()
             val startTime = now()
 
-            client.newCall(request).execute().use { response ->
-                result = handleResult(response, transactionId, paymentId)
-            }
-            requestLatency.record((now() - startTime).toDouble())
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    databaseThreadPool.submit {
+                        handleError(transactionId, paymentId, e)
+                        requestLatency.record((now() - startTime).toDouble())
+                    }
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    val responseCode = response.code
+                    val responseBody = response.body?.use { it.string() }?: ""
+                    databaseThreadPool.submit {
+                        handleSuccess(responseCode, responseBody, transactionId, paymentId)
+                        requestLatency.record((now() - startTime).toDouble())
+                    }
+                }
+            })
         }
-        return result
     }
 
-    fun handleResult(response: Response, transactionId: UUID, paymentId: UUID): Boolean {
+    private fun handleError(transactionId: UUID, paymentId: UUID, e: Exception) {
+        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+        paymentESService.update(paymentId) {
+            it.logProcessing(false, now(), transactionId, reason = e.message)
+        }
+    }
+
+    fun handleSuccess(responseCode: Int, responseBody: String, transactionId: UUID, paymentId: UUID): Boolean {
         val body = try {
-            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+            mapper.readValue(responseBody, ExternalSysResponse::class.java)
         } catch (e: Exception) {
-            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${responseCode}, reason: ${responseBody}")
             ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
         }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -140,7 +140,7 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long
     ): Boolean {
         semaphore.withPermit {
-            rate_limiter.tick()
+            rate_limiter.tickBlocking()
             sent_to_bank.increment()
 
             try {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -76,8 +76,8 @@ class PaymentExternalSystemAdapterImpl(
         .register(metricRegistry)
 
     private val dispatcher = Dispatcher().apply {
-        maxRequests = 10_000
-        maxRequestsPerHost = 10_000
+        maxRequests = parallelRequests
+        maxRequestsPerHost = parallelRequests
     }
 
     private val connectionPool = ConnectionPool(
@@ -102,11 +102,7 @@ class PaymentExternalSystemAdapterImpl(
         20,
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
-    ).apply {
-        setMaximumPoolSize(50)
-        setKeepAliveTime(10L, TimeUnit.MINUTES)
-        setRemoveOnCancelPolicy(true)
-    }
+    )
 
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -160,8 +156,18 @@ class PaymentExternalSystemAdapterImpl(
 
             sendRequestWithRetry(transactionId, paymentId, request, paymentStartedAt)
         } catch (e: Exception) {
-            databaseThreadPool.submit {
-                handleError(transactionId, paymentId, e)
+            when (e) {
+                is SocketTimeoutException -> {
+                    databaseThreadPool.submit {
+                        handleTimeout(transactionId, paymentId, e)
+                    }
+                }
+                else -> {
+                    databaseThreadPool.submit {
+                        handleError(transactionId, paymentId, e)
+                    }
+                }
+
             }
         }
     }
@@ -190,18 +196,26 @@ class PaymentExternalSystemAdapterImpl(
                 }
 
                 override fun onResponse(call: Call, response: Response) {
-                    val responseCode = response.code
-                    val responseBody = response.body?.use { it.string() } ?: ""
-                    databaseThreadPool.submit {
-                        val success = handleSuccess(responseCode, responseBody, transactionId, paymentId)
-                        requestLatency.record((now() - startTime).toDouble())
-                        onComplete(success)
+                    response.use {
+                        val responseCode = response.code
+                        val responseBody = response.body?.use { it.string() } ?: ""
+                        databaseThreadPool.submit {
+                            val success = handleSuccess(responseCode, responseBody, transactionId, paymentId)
+                            requestLatency.record((now() - startTime).toDouble())
+                            onComplete(success)
+                        }
                     }
                 }
             })
         }
     }
 
+    private fun handleTimeout(transactionId: UUID, paymentId: UUID, e: Exception) {
+        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+        paymentESService.update(paymentId) {
+            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+        }
+    }
 
     private fun handleError(transactionId: UUID, paymentId: UUID, e: Exception) {
         logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -18,6 +18,7 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import okhttp3.TlsVersion
 import okhttp3.internal.wait
 import okio.IOException
 import org.slf4j.LoggerFactory
@@ -88,15 +89,24 @@ class PaymentExternalSystemAdapterImpl(
         timeUnit = TimeUnit.MINUTES,
     )
 
+    private val connectionSpecs = listOf(
+        ConnectionSpec.CLEARTEXT,  // Для HTTP (ваш случай)
+        ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+            .build()
+    )
+
     private val client = OkHttpClient.Builder()
         .retryOnConnectionFailure(true)
         .connectTimeout(5_000, TimeUnit.MILLISECONDS)
-        .readTimeout(5_000, TimeUnit.MILLISECONDS)
+        .readTimeout(5_000, TimeUnit.SECONDS)
         .writeTimeout(5_000, TimeUnit.MILLISECONDS)
         .callTimeout(13_000, TimeUnit.MILLISECONDS)
         .connectionPool(connectionPool)
         .dispatcher(dispatcher)
         .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
+        .connectionSpecs(connectionSpecs)
+        .pingInterval(20, TimeUnit.SECONDS)
         .build()
 
     private val databaseThreadPool = ScheduledThreadPoolExecutor(
@@ -138,7 +148,7 @@ class PaymentExternalSystemAdapterImpl(
             sendRequest(transactionId, paymentId, request, paymentStartedAt) { success ->
                 if (!success && attempt < maxAttempts) {
                     databaseThreadPool.schedule({
-                        attempt(attempt + 1, delayMs * 2)
+                        attempt(attempt + 1, delayMs)
                     }, delayMs, TimeUnit.MILLISECONDS)
                 }
             }
@@ -197,14 +207,16 @@ class PaymentExternalSystemAdapterImpl(
                 }
 
                 override fun onResponse(call: Call, response: Response) {
+                    val responseCode: Int
+                    val responseBody: String
                     response.use {
-                        val responseCode = response.code
-                        val responseBody = response.body?.use { it.string() } ?: ""
-                        databaseThreadPool.submit {
-                            val success = handleSuccess(responseCode, responseBody, transactionId, paymentId)
-                            requestLatency.record((now() - startTime).toDouble())
-                            onComplete(success)
-                        }
+                        responseCode = response.code
+                        responseBody = response.body?.use { it.string() } ?: ""
+                    }
+                    databaseThreadPool.submit {
+                        val success = handleSuccess(responseCode, responseBody, transactionId, paymentId)
+                        requestLatency.record((now() - startTime).toDouble())
+                        onComplete(success)
                     }
                 }
             })

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -6,6 +6,8 @@ import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.kotlin.bulkhead.executeSuspendFunction
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.engine.jetty.jakarta.Jetty
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -107,25 +109,12 @@ class PaymentExternalSystemAdapterImpl(
 //            .build()
 //    )
 
-    private val client = HttpClient(io.ktor.client.engine.okhttp.OkHttp) {
+    private val client = HttpClient() {
 
         install(HttpTimeout) {
             requestTimeoutMillis = 13_000L
             connectTimeoutMillis = 5_000L
             socketTimeoutMillis = 5_000L
-        }
-
-        engine {
-            config {
-                // Reuse your existing OkHttp configuration
-                retryOnConnectionFailure(true)
-
-                // ENABLE HTTP/2 PROTOCOLS
-                protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
-
-                // Your existing connection pool
-                connectionPool(connectionPool)
-            }
         }
 
     }
@@ -158,15 +147,8 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     private suspend fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long) {
-        try {
-            val urlString = "http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"
-            sendRequestWithRetry(transactionId, paymentId, urlString, paymentStartedAt)
-        } catch (e: Exception) {
-            when (e) {
-                is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
-                else -> handleError(transactionId, paymentId, e)
-            }
-        }
+        val urlString = "http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"
+        sendRequestWithRetry(transactionId, paymentId, urlString, paymentStartedAt)
     }
 
     private suspend fun sendRequestWithRetry(
@@ -175,30 +157,13 @@ class PaymentExternalSystemAdapterImpl(
         url: String,
         paymentStartedAt: Long,
     ) {
-        val maxAttempts = 3;
-        val currentDelay = 2_000
-        var attempt = 0
-
-        while (attempt < maxAttempts) {
-            try {
-                if (sendRequest(transactionId, paymentId, url, paymentStartedAt)) {
-                    return
-                }
-            } catch (e: Exception) {
-
-            }
-            attempt++
-            if (attempt == maxAttempts) {
-                return
-            }
-        }
+        sendRequest(transactionId, paymentId, url)
     }
 
     suspend fun sendRequest(
         transactionId: UUID,
         paymentId: UUID,
         url: String,
-        paymentStartedAt: Long
     ): Boolean {
         semaphore.withPermit {
             sent_to_bank.increment()
@@ -212,11 +177,12 @@ class PaymentExternalSystemAdapterImpl(
                     transactionId,
                     paymentId
                 )
-                requestLatency.record((now() - startTime).toDouble())
-                return true
+                return success
             } catch (e: Exception) {
-                requestLatency.record((now() - startTime).toDouble())
-                handleError(transactionId, paymentId, e)
+                when (e) {
+                    is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
+                    else -> handleError(transactionId, paymentId, e)
+                }
                 return false
             }
         }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -4,50 +4,39 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
-import io.github.resilience4j.kotlin.bulkhead.executeSuspendFunction
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.jetty.jakarta.Jetty
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
+import io.ktor.websocket.WebSocketDeflateExtension.Companion.install
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
-import io.prometheus.metrics.core.metrics.Summary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
-import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
-import okhttp3.ConnectionSpec
-import okhttp3.Dispatcher
-import okhttp3.Protocol
-import okhttp3.Request
 import okhttp3.RequestBody
-import okhttp3.TlsVersion
-import okio.IOException
+import org.eclipse.jetty.http2.client.HTTP2Client
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
-import java.lang.Thread.sleep
 import java.net.SocketTimeoutException
-import java.sql.Time
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import kotlin.concurrent.thread
 
 
 // Advice: always treat time as a Duration
@@ -91,32 +80,26 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentiles( 0.9, 0.99, 0.999, 0.9999)
         .register(metricRegistry)
 
-    private val dispatcher = Dispatcher().apply {
-        maxRequests = parallelRequests
-        maxRequestsPerHost = parallelRequests
-    }
+    private val dispatcherClient = Executors.newFixedThreadPool(20).asCoroutineDispatcher()
 
-    private val connectionPool = ConnectionPool(
+    private val connectionPoolClient = ConnectionPool(
         maxIdleConnections = 50,
         keepAliveDuration = 13,
         timeUnit = TimeUnit.MINUTES,
     )
 
-//    private val connectionSpecs = listOf(
-//        ConnectionSpec.CLEARTEXT,
-//        ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-//            .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
-//            .build()
-//    )
-
-    private val client = HttpClient() {
+    private val client = HttpClient(Jetty) {
 
         install(HttpTimeout) {
             requestTimeoutMillis = 13_000L
             connectTimeoutMillis = 5_000L
-            socketTimeoutMillis = 5_000L
+            socketTimeoutMillis = 30_000L
         }
 
+        engine {
+            pipelining=true
+            dispatcher=dispatcherClient
+        }
     }
 
     private val databaseThreadPool = ScheduledThreadPoolExecutor(

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -4,22 +4,31 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.kotlin.bulkhead.executeSuspendFunction
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.prometheus.metrics.core.metrics.Summary
-import okhttp3.Call
-import okhttp3.Callback
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
 import okhttp3.ConnectionSpec
 import okhttp3.Dispatcher
-import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
-import okhttp3.Response
 import okhttp3.TlsVersion
-import okhttp3.internal.wait
 import okio.IOException
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
@@ -27,6 +36,7 @@ import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.lang.Thread.sleep
 import java.net.SocketTimeoutException
 import java.sql.Time
 import java.time.Duration
@@ -35,6 +45,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 
 // Advice: always treat time as a Duration
@@ -89,31 +100,43 @@ class PaymentExternalSystemAdapterImpl(
         timeUnit = TimeUnit.MINUTES,
     )
 
-    private val connectionSpecs = listOf(
-        ConnectionSpec.CLEARTEXT,  // Для HTTP (ваш случай)
-        ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-            .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
-            .build()
-    )
+//    private val connectionSpecs = listOf(
+//        ConnectionSpec.CLEARTEXT,
+//        ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+//            .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+//            .build()
+//    )
 
-    private val client = OkHttpClient.Builder()
-        .retryOnConnectionFailure(true)
-        .connectTimeout(5_000, TimeUnit.MILLISECONDS)
-        .readTimeout(5_000, TimeUnit.SECONDS)
-        .writeTimeout(5_000, TimeUnit.MILLISECONDS)
-        .callTimeout(13_000, TimeUnit.MILLISECONDS)
-        .connectionPool(connectionPool)
-        .dispatcher(dispatcher)
-        .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
-        .connectionSpecs(connectionSpecs)
-        .pingInterval(20, TimeUnit.SECONDS)
-        .build()
+    private val client = HttpClient(io.ktor.client.engine.okhttp.OkHttp) {
+
+        install(HttpTimeout) {
+            requestTimeoutMillis = 13_000L
+            connectTimeoutMillis = 5_000L
+            socketTimeoutMillis = 5_000L
+        }
+
+        engine {
+            config {
+                // Reuse your existing OkHttp configuration
+                retryOnConnectionFailure(true)
+
+                // ENABLE HTTP/2 PROTOCOLS
+                protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
+
+                // Your existing connection pool
+                connectionPool(connectionPool)
+            }
+        }
+
+    }
 
     private val databaseThreadPool = ScheduledThreadPoolExecutor(
         20,
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )
+
+    private val semaphore = Semaphore(permits = parallelRequests)
 
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -123,103 +146,79 @@ class PaymentExternalSystemAdapterImpl(
 
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        databaseThreadPool.submit {
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
-            }
+        paymentESService.update(paymentId) {
+            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        bankPayment(transactionId, paymentId, amount, paymentStartedAt)
-    }
-
-    fun sendRequestWithRetry(
-        transactionId: UUID,
-        paymentId: UUID,
-        request: Request,
-        paymentStartedAt: Long,
-        maxAttempts: Int = 3,
-        initialDelayMs: Long = 2_000L
-    ) {
-        fun attempt(attempt: Int, delayMs: Long) {
-            if (attempt > maxAttempts) return
-
-            sendRequest(transactionId, paymentId, request, paymentStartedAt) { success ->
-                if (!success && attempt < maxAttempts) {
-                    databaseThreadPool.schedule({
-                        attempt(attempt + 1, delayMs)
-                    }, delayMs, TimeUnit.MILLISECONDS)
-                }
-            }
+        CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
+            bankPayment(transactionId, paymentId, amount, paymentStartedAt)
         }
-
-        attempt(1, initialDelayMs)
     }
 
-
-    fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long) {
+    private suspend fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long) {
         try {
-            val request = Request.Builder().run {
-                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                post(emptyBody)
-            }.build()
-
-            sendRequestWithRetry(transactionId, paymentId, request, paymentStartedAt)
+            val urlString = "http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"
+            sendRequestWithRetry(transactionId, paymentId, urlString, paymentStartedAt)
         } catch (e: Exception) {
             when (e) {
-                is SocketTimeoutException -> {
-                    databaseThreadPool.submit {
-                        handleTimeout(transactionId, paymentId, e)
-                    }
-                }
-                else -> {
-                    databaseThreadPool.submit {
-                        handleError(transactionId, paymentId, e)
-                    }
-                }
-
+                is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
+                else -> handleError(transactionId, paymentId, e)
             }
         }
     }
 
-
-    fun sendRequest(
+    private suspend fun sendRequestWithRetry(
         transactionId: UUID,
         paymentId: UUID,
-        request: Request,
+        url: String,
         paymentStartedAt: Long,
-        onComplete: (Boolean) -> Unit
     ) {
-        bulkhead.executeCallable {
-            rate_limiter.tickBlocking()
+        val maxAttempts = 3;
+        val currentDelay = 2_000
+        var attempt = 0
 
+        while (attempt < maxAttempts) {
+            try {
+                if (sendRequest(transactionId, paymentId, url, paymentStartedAt)) {
+                    return
+                }
+            } catch (e: Exception) {
+
+            }
+            attempt++
+            if (attempt == maxAttempts) {
+                return
+            }
+        }
+    }
+
+    suspend fun sendRequest(
+        transactionId: UUID,
+        paymentId: UUID,
+        url: String,
+        paymentStartedAt: Long
+    ): Boolean {
+        semaphore.withPermit {
             sent_to_bank.increment()
             val startTime = now()
 
-            client.newCall(request).enqueue(object : Callback {
-                override fun onFailure(call: Call, e: IOException) {
-                    databaseThreadPool.submit {
-                        handleError(transactionId, paymentId, e)
-                        requestLatency.record((now() - startTime).toDouble())
-                        onComplete(false)
-                    }
-                }
-
-                override fun onResponse(call: Call, response: Response) {
-                    val responseCode: Int
-                    val responseBody: String
-                    response.use {
-                        responseCode = response.code
-                        responseBody = response.body?.use { it.string() } ?: ""
-                    }
-                    databaseThreadPool.submit {
-                        val success = handleSuccess(responseCode, responseBody, transactionId, paymentId)
-                        requestLatency.record((now() - startTime).toDouble())
-                        onComplete(success)
-                    }
-                }
-            })
+            try {
+                val response = client.post(url) { setBody("") }
+                val success = handleSuccess(
+                    response.status.value,
+                    response.bodyAsText(),
+                    transactionId,
+                    paymentId
+                )
+                requestLatency.record((now() - startTime).toDouble())
+                return true
+            } catch (e: Exception) {
+                requestLatency.record((now() - startTime).toDouble())
+                handleError(transactionId, paymentId, e)
+                return false
+            }
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -81,22 +81,20 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     private val connectionPool = ConnectionPool(
-        maxIdleConnections = 20,
+        maxIdleConnections = 50,
         keepAliveDuration = 13,
         timeUnit = TimeUnit.MINUTES,
     )
 
     private val client = OkHttpClient.Builder()
         .retryOnConnectionFailure(true)
-        .connectTimeout(15_000, TimeUnit.MILLISECONDS)
-        .readTimeout(15_000, TimeUnit.MILLISECONDS)
-        .writeTimeout(15_000, TimeUnit.MILLISECONDS)
-        .callTimeout(23_000, TimeUnit.MILLISECONDS)
+        .connectTimeout(5_000, TimeUnit.MILLISECONDS)
+        .readTimeout(5_000, TimeUnit.MILLISECONDS)
+        .writeTimeout(5_000, TimeUnit.MILLISECONDS)
+        .callTimeout(13_000, TimeUnit.MILLISECONDS)
         .connectionPool(connectionPool)
         .dispatcher(dispatcher)
         .build()
-
-    private var orderMap = HashMap<UUID, Long>()
 
     private val databaseThreadPool = ScheduledThreadPoolExecutor(
         20,

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -29,6 +29,7 @@ import java.sql.Time
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
@@ -81,31 +82,32 @@ class PaymentExternalSystemAdapterImpl(
 
     private val connectionPool = ConnectionPool(
         maxIdleConnections = 20,
-        keepAliveDuration = 5,
+        keepAliveDuration = 13,
         timeUnit = TimeUnit.MINUTES,
     )
 
     private val client = OkHttpClient.Builder()
         .retryOnConnectionFailure(true)
-        .connectTimeout(13_000, TimeUnit.MILLISECONDS)
-        .readTimeout(13_000, TimeUnit.MILLISECONDS)
-        .writeTimeout(13_000, TimeUnit.MILLISECONDS)
-        .callTimeout(13_000, TimeUnit.MILLISECONDS)
+        .connectTimeout(15_000, TimeUnit.MILLISECONDS)
+        .readTimeout(15_000, TimeUnit.MILLISECONDS)
+        .writeTimeout(15_000, TimeUnit.MILLISECONDS)
+        .callTimeout(23_000, TimeUnit.MILLISECONDS)
         .connectionPool(connectionPool)
         .dispatcher(dispatcher)
         .build()
 
-    private val databaseThreadPool = ThreadPoolExecutor(
+    private var orderMap = HashMap<UUID, Long>()
+
+    private val databaseThreadPool = ScheduledThreadPoolExecutor(
         20,
-        20,
-        7L,
-        TimeUnit.MINUTES,
-        LinkedBlockingQueue(500_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
-    )
+    ).apply {
+        setMaximumPoolSize(50)
+        setKeepAliveTime(10L, TimeUnit.MINUTES)
+        setRemoveOnCancelPolicy(true)
+    }
 
-    private var orderMap = HashMap<UUID, Long>()
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -125,6 +127,30 @@ class PaymentExternalSystemAdapterImpl(
         bankPayment(transactionId, paymentId, amount, paymentStartedAt)
     }
 
+    fun sendRequestWithRetry(
+        transactionId: UUID,
+        paymentId: UUID,
+        request: Request,
+        paymentStartedAt: Long,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 2_000L
+    ) {
+        fun attempt(attempt: Int, delayMs: Long) {
+            if (attempt > maxAttempts) return
+
+            sendRequest(transactionId, paymentId, request, paymentStartedAt) { success ->
+                if (!success && attempt < maxAttempts) {
+                    databaseThreadPool.schedule({
+                        attempt(attempt + 1, delayMs * 2)
+                    }, delayMs, TimeUnit.MILLISECONDS)
+                }
+            }
+        }
+
+        attempt(1, initialDelayMs)
+    }
+
+
     fun bankPayment(transactionId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long) {
         try {
             val request = Request.Builder().run {
@@ -132,7 +158,7 @@ class PaymentExternalSystemAdapterImpl(
                 post(emptyBody)
             }.build()
 
-            sendRequest(transactionId, paymentId, request, paymentStartedAt)
+            sendRequestWithRetry(transactionId, paymentId, request, paymentStartedAt)
         } catch (e: Exception) {
             databaseThreadPool.submit {
                 handleError(transactionId, paymentId, e)
@@ -140,7 +166,14 @@ class PaymentExternalSystemAdapterImpl(
         }
     }
 
-    fun sendRequest(transactionId: UUID, paymentId: UUID, request: Request, paymentStartedAt: Long) {
+
+    fun sendRequest(
+        transactionId: UUID,
+        paymentId: UUID,
+        request: Request,
+        paymentStartedAt: Long,
+        onComplete: (Boolean) -> Unit
+    ) {
         bulkhead.executeCallable {
             rate_limiter.tickBlocking()
 
@@ -152,20 +185,23 @@ class PaymentExternalSystemAdapterImpl(
                     databaseThreadPool.submit {
                         handleError(transactionId, paymentId, e)
                         requestLatency.record((now() - startTime).toDouble())
+                        onComplete(false)
                     }
                 }
 
                 override fun onResponse(call: Call, response: Response) {
                     val responseCode = response.code
-                    val responseBody = response.body?.use { it.string() }?: ""
+                    val responseBody = response.body?.use { it.string() } ?: ""
                     databaseThreadPool.submit {
-                        handleSuccess(responseCode, responseBody, transactionId, paymentId)
+                        val success = handleSuccess(responseCode, responseBody, transactionId, paymentId)
                         requestLatency.record((now() - startTime).toDouble())
+                        onComplete(success)
                     }
                 }
             })
         }
     }
+
 
     private fun handleError(transactionId: UUID, paymentId: UUID, e: Exception) {
         logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -81,33 +81,31 @@ class PaymentExternalSystemAdapterImpl(
 
     private val connectionPool = ConnectionPool(
         maxIdleConnections = 20,
-        keepAliveDuration = 7,
+        keepAliveDuration = 5,
         timeUnit = TimeUnit.MINUTES,
     )
 
     private val client = OkHttpClient.Builder()
         .retryOnConnectionFailure(true)
-        .connectTimeout(23_000, TimeUnit.MILLISECONDS)
-        .readTimeout(23_000, TimeUnit.MILLISECONDS)
-        .writeTimeout(23_000, TimeUnit.MILLISECONDS)
-        .callTimeout(23_000, TimeUnit.MILLISECONDS)
+        .connectTimeout(13_000, TimeUnit.MILLISECONDS)
+        .readTimeout(13_000, TimeUnit.MILLISECONDS)
+        .writeTimeout(13_000, TimeUnit.MILLISECONDS)
+        .callTimeout(13_000, TimeUnit.MILLISECONDS)
         .connectionPool(connectionPool)
         .dispatcher(dispatcher)
         .build()
 
     private val databaseThreadPool = ThreadPoolExecutor(
         20,
-        50,
-        0L,
-        TimeUnit.MILLISECONDS,
+        20,
+        7L,
+        TimeUnit.MINUTES,
         LinkedBlockingQueue(500_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )
 
     private var orderMap = HashMap<UUID, Long>()
-
-
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -6,6 +6,7 @@ import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.java.Java
 import io.ktor.client.engine.jetty.jakarta.Jetty
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
@@ -19,15 +20,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import okhttp3.ConnectionPool
 import okhttp3.RequestBody
-import org.eclipse.jetty.http2.client.HTTP2Client
 import org.slf4j.LoggerFactory
-import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
-import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
@@ -35,11 +35,7 @@ import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 
-
-// Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
     private val properties: PaymentAccountProperties,
     private val paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
@@ -61,10 +57,6 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
     private val rate_limiter = SlidingWindowRateLimiter(rateLimitPerSec * 1L, Duration.ofMillis(1000))
-    private val bulkhead = Bulkhead.of("http-client", BulkheadConfig.custom()
-        .maxConcurrentCalls(parallelRequests)
-        .maxWaitDuration(Duration.ofMillis(1_000_000))
-        .build())
 
     private val sent_to_bank: Counter = Counter
         .builder("sent_request_to_bank")
@@ -80,20 +72,13 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentiles( 0.9, 0.99, 0.999, 0.9999)
         .register(metricRegistry)
 
-    private val dispatcherClient = Executors.newFixedThreadPool(20).asCoroutineDispatcher()
+    private val dispatcherClient = Executors.newFixedThreadPool(30).asCoroutineDispatcher()
+    private val dispatcherPayment = Executors.newFixedThreadPool(30).asCoroutineDispatcher()
 
-    private val connectionPoolClient = ConnectionPool(
-        maxIdleConnections = 50,
-        keepAliveDuration = 13,
-        timeUnit = TimeUnit.MINUTES,
-    )
-
-    private val client = HttpClient(Jetty) {
+    private val client = HttpClient(Java) {
 
         install(HttpTimeout) {
-            requestTimeoutMillis = 13_000L
-            connectTimeoutMillis = 5_000L
-            socketTimeoutMillis = 30_000L
+            requestTimeoutMillis = 20_000L
         }
 
         engine {
@@ -101,12 +86,6 @@ class PaymentExternalSystemAdapterImpl(
             dispatcher=dispatcherClient
         }
     }
-
-    private val databaseThreadPool = ScheduledThreadPoolExecutor(
-        20,
-        NamedThreadFactory("payment-submission-executor"),
-        CallerBlockingRejectedExecutionHandler()
-    )
 
     private val semaphore = Semaphore(permits = parallelRequests)
 
@@ -124,7 +103,7 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
+        CoroutineScope(dispatcherPayment + SupervisorJob()).launch {
             bankPayment(transactionId, paymentId, amount, paymentStartedAt)
         }
     }
@@ -140,17 +119,29 @@ class PaymentExternalSystemAdapterImpl(
         url: String,
         paymentStartedAt: Long,
     ) {
-        sendRequest(transactionId, paymentId, url)
+
+        val delayMs = 3000L
+        val maxRetries = 3
+        var curRetry = 1
+
+        while (curRetry < maxRetries) {
+            if (sendRequest(transactionId, paymentId, url, paymentStartedAt)) {
+                return
+            }
+            delay(delayMs)
+            curRetry += 1
+        }
     }
 
     suspend fun sendRequest(
         transactionId: UUID,
         paymentId: UUID,
         url: String,
+        paymentStartedAt: Long
     ): Boolean {
         semaphore.withPermit {
+            rate_limiter.tick()
             sent_to_bank.increment()
-            val startTime = now()
 
             try {
                 val response = client.post(url) { setBody("") }
@@ -160,12 +151,14 @@ class PaymentExternalSystemAdapterImpl(
                     transactionId,
                     paymentId
                 )
+                requestLatency.record((now() - paymentStartedAt).toDouble())
                 return success
             } catch (e: Exception) {
                 when (e) {
                     is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
                     else -> handleError(transactionId, paymentId, e)
                 }
+                requestLatency.record((now() - paymentStartedAt).toDouble())
                 return false
             }
         }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -11,8 +11,10 @@ import io.prometheus.metrics.core.metrics.Summary
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.ConnectionPool
+import okhttp3.ConnectionSpec
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
@@ -81,7 +83,7 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     private val connectionPool = ConnectionPool(
-        maxIdleConnections = parallelRequests,
+        maxIdleConnections = 50,
         keepAliveDuration = 13,
         timeUnit = TimeUnit.MINUTES,
     )
@@ -94,6 +96,7 @@ class PaymentExternalSystemAdapterImpl(
         .callTimeout(13_000, TimeUnit.MILLISECONDS)
         .connectionPool(connectionPool)
         .dispatcher(dispatcher)
+        .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
         .build()
 
     private val databaseThreadPool = ScheduledThreadPoolExecutor(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-9
+payment.accounts=acc-12
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,9 +3,9 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <logger name="ru.quipy" level="INFO"/>
+    <logger name="ru.quipy" level="ERROR"/>
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Настройки аккаунта:
1. Число одновременно исполняющихся задач - 20'000.
2. Максимальное число проксируемых запросов в секунду - 1100.
3. Среднее время исполнения запроса - 10 секунд.

## Условия теста:
1. Число запросов в секунду - 1000.
2. Максимальное время исполнения запроса - 50 секунд.

## Резульаты до:

### Число успешных тестов:
<img width="1280" height="518" alt="image" src="https://github.com/user-attachments/assets/3deb4148-e542-4598-9432-1335d6b21233" />

### Входящий и исходящий rps
<img width="1280" height="537" alt="image" src="https://github.com/user-attachments/assets/3032ec77-f074-49f0-8c17-7b93c5077871" />

## Решение

### Первая мысль
Что если использовать thread pool большего размера? Во-первых заметим, что решить этот кейс, как предыдущий не получится. Посчитаем сколько потоков потребуется:

1 поток выполняет 0.1 запроса в секунду
1000 / 0.1 = 10'000 потоков

Один поток требует по крайней мере 4 МБ памяти под стек. Посчитаем сколько памяти нужно для такого количества потоков:

10'000 * 4 МБ = 40 Гб оперативной памяти.

### Вторая мысль
Что если использовать асинхроность? Для этого мы переписали весь код вызова банка на suspend функции. После добавления корутин не было смысла в таком большом thread pool-е, поэтому уменьшили число потоков в нем, а также увеличили размер очереди.

### Третья мысль
Что если настроить okHTTP-клиент. Сначала мы подбирали разные виды таймаутов от connect до call. Далее создали отдельный thread pool на соединения, перебирали разные параметры. Прочитали про HOL-проблему и настроили клиент на использование HTTPv1.1 или HTTPv2. Ничто из этого не помогло.

### Четвертая мысль
Что если делать все транзации в БД в новом CoroutineScope? Мы подумали, что операции работы с БД блокирующии и при такой нагрузки, мы теряем много времени на запись. По идее если вынести эту работу в отдельный CoroutineScope при этом, сразу сообщая пользователю результат операции с банком, то мы сможем сильно сэкономить на ответе. К сожалению, и эта идея не привела нас к успеху.

### Пятая мысль
Что если заменить http-клиента? От отчаяния мы решили попробовать использовать другую библиотеку. Выбрали несколько из них и переписывали код на работу с ними. Мы пробовали ctor с разными видами движков и выбрали Java, так как его резульаты были сильно лучше, чем у okHTTP. Замена клиента сразу показала значительно лучше результаты.

## Результаты после:

### Число успешных тестов
<img width="1280" height="546" alt="image" src="https://github.com/user-attachments/assets/053f9bdd-fff5-4f46-93e6-f74423b04be0" />

### Входящий и исходящий rps
<img width="1280" height="546" alt="image" src="https://github.com/user-attachments/assets/62a186c7-7cb8-4c8a-a402-c0c542881eb1" />

### Число потоков
<img width="1280" height="559" alt="image" src="https://github.com/user-attachments/assets/0a71784e-7f25-49e3-b3bc-930b96c34d60" />

### Число соединений
<img width="1280" height="559" alt="image" src="https://github.com/user-attachments/assets/c1caa52f-1de9-4e85-a6b4-34be8edf3b23" />


