### PR TITLE
HW #10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,11 @@
             <artifactId>resilience4j-timelimiter</artifactId>
             <version>${resilience4jVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-kotlin</artifactId>
+            <version>2.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -37,7 +37,7 @@ class APIController {
     data class User(val id: UUID, val name: String)
 
     fun dropRequest(): ResponseEntity<PaymentSubmissionDto> {
-        val now = System.currentTimeMillis() + 150
+        val now = System.currentTimeMillis() + 30
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", now.toString()).build()
     }
 

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -37,7 +37,7 @@ class APIController {
     data class User(val id: UUID, val name: String)
 
     fun dropRequest(): ResponseEntity<PaymentSubmissionDto> {
-        val now = System.currentTimeMillis() + 5_000
+        val now = System.currentTimeMillis() + 150
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", now.toString()).build()
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -33,9 +33,9 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    fun tickBlocking() {
+    suspend fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(10)
+            delay(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -29,18 +29,18 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        10,
-        10,
+        20,
+        20,
         0L,
         TimeUnit.MILLISECONDS,
-        LinkedBlockingQueue(5_000),
+        LinkedBlockingQueue(10_000),
         NamedThreadFactory("payment-submission-executor"),
         ThreadPoolExecutor.DiscardOldestPolicy()
     )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        if (paymentExecutor.queue.size > 4500) {
+        if (paymentExecutor.queue.size > 5000) {
             return -1
         }
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -72,13 +72,13 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentiles( 0.9, 0.99, 0.999, 0.9999)
         .register(metricRegistry)
 
-    private val dispatcherClient = Executors.newFixedThreadPool(30).asCoroutineDispatcher()
-    private val dispatcherPayment = Executors.newFixedThreadPool(30).asCoroutineDispatcher()
+    private val dispatcherClient = Executors.newFixedThreadPool(40).asCoroutineDispatcher()
+    private val dispatcherPayment = Executors.newFixedThreadPool(40).asCoroutineDispatcher()
 
     private val client = HttpClient(Java) {
 
         install(HttpTimeout) {
-            requestTimeoutMillis = 20_000L
+            requestTimeoutMillis = 1000L
         }
 
         engine {
@@ -120,11 +120,14 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
     ) {
 
-        val delayMs = 3000L
+        val delayMs = 100L
         val maxRetries = 3
         var curRetry = 1
 
         while (curRetry < maxRetries) {
+//            if (now() - paymentStartedAt > 700) {
+//                handleTimeout(transactionId, paymentId, Exception("No time to execute"))
+//            }
             if (sendRequest(transactionId, paymentId, url, paymentStartedAt)) {
                 return
             }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.kotlin.ratelimiter.executeSuspendFunction
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.java.Java
@@ -56,7 +59,11 @@ class PaymentExternalSystemAdapterImpl(
     private val requestAverageProcessingTime = properties.averageProcessingTime
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
-    private val rate_limiter = SlidingWindowRateLimiter(rateLimitPerSec * 1L, Duration.ofMillis(1000))
+    private val rateLimiter = RateLimiter.of("rate-limiter", RateLimiterConfig.custom()
+        .limitForPeriod(rateLimitPerSec)
+        .limitRefreshPeriod(Duration.ofMillis(1000))
+        .build()
+    )
 
     private val sent_to_bank: Counter = Counter
         .builder("sent_request_to_bank")
@@ -72,8 +79,8 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentiles( 0.9, 0.99, 0.999, 0.9999)
         .register(metricRegistry)
 
-    private val dispatcherClient = Executors.newFixedThreadPool(40).asCoroutineDispatcher()
-    private val dispatcherPayment = Executors.newFixedThreadPool(40).asCoroutineDispatcher()
+    private val dispatcherClient = Executors.newFixedThreadPool(60).asCoroutineDispatcher()
+    private val dispatcherPayment = Executors.newFixedThreadPool(60).asCoroutineDispatcher()
 
     private val client = HttpClient(Java) {
 
@@ -125,9 +132,6 @@ class PaymentExternalSystemAdapterImpl(
         var curRetry = 1
 
         while (curRetry < maxRetries) {
-//            if (now() - paymentStartedAt > 700) {
-//                handleTimeout(transactionId, paymentId, Exception("No time to execute"))
-//            }
             if (sendRequest(transactionId, paymentId, url, paymentStartedAt)) {
                 return
             }
@@ -142,29 +146,33 @@ class PaymentExternalSystemAdapterImpl(
         url: String,
         paymentStartedAt: Long
     ): Boolean {
+        var result = false
         semaphore.withPermit {
-            rate_limiter.tickBlocking()
-            sent_to_bank.increment()
+            rateLimiter.executeSuspendFunction {
 
-            try {
-                val response = client.post(url) { setBody("") }
-                val success = handleSuccess(
-                    response.status.value,
-                    response.bodyAsText(),
-                    transactionId,
-                    paymentId
-                )
-                requestLatency.record((now() - paymentStartedAt).toDouble())
-                return success
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
-                    else -> handleError(transactionId, paymentId, e)
+                sent_to_bank.increment()
+
+                try {
+                    val response = client.post(url) { setBody("") }
+                    val success = handleSuccess(
+                        response.status.value,
+                        response.bodyAsText(),
+                        transactionId,
+                        paymentId
+                    )
+                    requestLatency.record((now() - paymentStartedAt).toDouble())
+                    result = success
+                } catch (e: Exception) {
+                    when (e) {
+                        is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
+                        else -> handleError(transactionId, paymentId, e)
+                    }
+                    requestLatency.record((now() - paymentStartedAt).toDouble())
+                    result = false
                 }
-                requestLatency.record((now() - paymentStartedAt).toDouble())
-                return false
             }
         }
+        return result
     }
 
     private fun handleTimeout(transactionId: UUID, paymentId: UUID, e: Exception) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-12
+payment.accounts=acc-13
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
## Настройки аккаунта:
1. Число одновременно исполняющихся задач - 2000.
2. Максимальное число проксируемых запросов в секунду - 5000.
3. Среднее время исполнения запроса - 0.01 секунд.
## Условия теста:
1. Число запросов в секунду - 4000.
2. Максимальное время исполнения запроса - 1 секунда.

## Результаты до
### Число успешных тестов
<img width="1470" height="598" alt="image" src="https://github.com/user-attachments/assets/53a636c5-6b42-4fe1-a537-5775fb72215b" />

### Входящий и исходящий rps
<img width="1470" height="598" alt="image" src="https://github.com/user-attachments/assets/85062c00-dc94-4949-b403-c8b3bd2b92b8" />

## Решение
Увидели, что запросы исполняются очень быстро, примерно 10мс, поэтому изменили таймаут у клиента на 1 секунду (максимальное время ожидания от клиента). После запуска наблюдали большое число исключений в консоле. Все они были связаны с "request timeout". Решили ограничить очередь thread pool до 5000 запросов, так как именно столько разрешает обработать rate limiter. Все остальные запросы отправляли с 'Retry-After'. Перебрали разные варианты заголовка и решили остановится на 30 мс. 

Также проверели используемый у нас rate limiter. Это была станадартная реализация SlidingWindowRateLimiter, которая под капотом делала Thread.sleep. Так как мы вызывались из корутин, то это было неприемлимо, поэтому заменили на resilience4j.RateLimiter.

## Результаты после
### Число успешных тестов
<img width="1280" height="526" alt="image" src="https://github.com/user-attachments/assets/749c12f6-636a-40f3-9e38-e48d52804e50" />

### Входящий и исходящий rps
<img width="1280" height="526" alt="image" src="https://github.com/user-attachments/assets/d44ec287-2a0f-4467-b147-8d6a5c6cc019" />

### Выручка
<img width="1280" height="534" alt="image" src="https://github.com/user-attachments/assets/eb7e566b-bb8e-4821-a47e-2eb7213ec193" />

### Удаленный запуск
<img width="732" height="613" alt="image" src="https://github.com/user-attachments/assets/8d9c4590-5ebc-4cf4-8603-46b469d6fb51" />

