### PR TITLE
HW #11

### DIFF
--- a/grafana/provisioning/dashboards/ServicesStatistic.json
+++ b/grafana/provisioning/dashboards/ServicesStatistic.json
@@ -1207,7 +1207,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "rate(repeat_request_total[20s])*20",
+          "expr": "rate(repeat_request_total[20s])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -1307,13 +1307,106 @@
           "expr": "request_latency",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "{{quantile}}",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
       "title": "Quantile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(hedged_request_total[20s])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Hedged request",
       "type": "timeseries"
     },
     {
@@ -3723,5 +3816,5 @@
   "timezone": "",
   "title": "Services statistic",
   "uid": "KVr-Vmpnz",
-  "version": 12
+  "version": 3
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,25 +2,21 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.github.resilience4j.bulkhead.Bulkhead
-import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.kotlin.ratelimiter.executeSuspendFunction
 import io.github.resilience4j.ratelimiter.RateLimiter
 import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.java.Java
-import io.ktor.client.engine.jetty.jakarta.Jetty
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
-import io.ktor.websocket.WebSocketDeflateExtension.Companion.install
+import io.ktor.http.headers
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.coroutineScope
@@ -28,16 +24,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
-import okhttp3.ConnectionPool
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
-import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PaymentExternalSystemAdapterImpl(
     private val properties: PaymentAccountProperties,
@@ -70,8 +65,12 @@ class PaymentExternalSystemAdapterImpl(
         .tags("account_name", accountName)
         .register(metricRegistry)
 
-    private val repeat_request: Counter = Counter
+    private val repeatRequest: Counter = Counter
         .builder("repeat_request")
+        .register(metricRegistry)
+
+    private val hedgedRequest: Counter = Counter
+        .builder("hedged_request")
         .register(metricRegistry)
 
     var requestLatency: DistributionSummary = DistributionSummary
@@ -85,7 +84,7 @@ class PaymentExternalSystemAdapterImpl(
     private val client = HttpClient(Java) {
 
         install(HttpTimeout) {
-            requestTimeoutMillis = 1000L
+            requestTimeoutMillis = 1500L
         }
 
         engine {
@@ -127,12 +126,15 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
     ) {
 
-        val delayMs = 100L
-        val maxRetries = 3
+        val delayMs = 0L
+        val maxRetries = 2
         var curRetry = 1
 
         while (curRetry < maxRetries) {
-            if (sendRequest(transactionId, paymentId, url, paymentStartedAt)) {
+            if (curRetry > 1) {
+                repeatRequest.increment()
+            }
+            if (sendRequestWithLimiting(transactionId, paymentId, url, paymentStartedAt)) {
                 return
             }
             delay(delayMs)
@@ -140,38 +142,100 @@ class PaymentExternalSystemAdapterImpl(
         }
     }
 
-    suspend fun sendRequest(
+    suspend fun sendRequestWithLimiting(
         transactionId: UUID,
         paymentId: UUID,
         url: String,
-        paymentStartedAt: Long
+        paymentStartedAt: Long,
     ): Boolean {
-        var result = false
+        var result = true
         semaphore.withPermit {
             rateLimiter.executeSuspendFunction {
 
                 sent_to_bank.increment()
+                result = sendHedgedRequest(transactionId, paymentId, url, paymentStartedAt)
 
-                try {
-                    val response = client.post(url) { setBody("") }
-                    val success = handleSuccess(
-                        response.status.value,
-                        response.bodyAsText(),
-                        transactionId,
-                        paymentId
-                    )
-                    requestLatency.record((now() - paymentStartedAt).toDouble())
-                    result = success
-                } catch (e: Exception) {
-                    when (e) {
-                        is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
-                        else -> handleError(transactionId, paymentId, e)
-                    }
-                    requestLatency.record((now() - paymentStartedAt).toDouble())
-                    result = false
-                }
             }
         }
+        return result
+    }
+
+    suspend fun sendHedgedRequest(
+        transactionId: UUID,
+        paymentId: UUID,
+        url: String,
+        paymentStartedAt: Long,
+    ): Boolean {
+
+        val idempotencyKey = UUID.randomUUID().toString()
+        val requestJob = SupervisorJob()
+        var result = AtomicBoolean(false)
+        val completed = AtomicBoolean(false)
+        val responseReceived = CompletableDeferred<Boolean>()
+
+        coroutineScope {
+            val primaryJob = launch(requestJob) {
+                val ok = sendRequest(transactionId, paymentId, url, paymentStartedAt, idempotencyKey)
+                if (ok) {
+                    result.compareAndSet(false, true)
+                }
+                if (completed.compareAndSet(false, true)) {
+                    responseReceived.complete(true)
+                }
+            }
+
+            val hedgedJob = launch(requestJob) {
+                delay(300)
+                if (!completed.get()){
+                    hedgedRequest.increment()
+                    val ok = sendRequest(transactionId, paymentId, url, paymentStartedAt, idempotencyKey)
+                    if (ok) {
+                        result.compareAndSet(false, true)
+                    }
+                    if (completed.compareAndSet(false, true)) {
+                        responseReceived.complete(true)
+                    }
+                }
+            }
+
+            val allJobs = listOf(primaryJob) + hedgedJob
+            if (completed.get()) {
+                allJobs.forEach { it.cancel() }
+            }
+        }
+        return result.get()
+    }
+
+    private suspend fun sendRequest(
+        transactionId: UUID,
+        paymentId: UUID,
+        url: String,
+        paymentStartedAt: Long,
+        idempotencyKey: String
+    ): Boolean {
+        var result = false
+        try {
+            val response = client.post(url) {
+                setBody("")
+                headers {
+                    append("x-idempotency-key", idempotencyKey)
+                }
+            }
+            val success = handleSuccess(
+                response.status.value,
+                response.bodyAsText(),
+                transactionId,
+                paymentId
+            )
+            result = success
+        } catch (e: Exception) {
+            when (e) {
+                is SocketTimeoutException -> handleTimeout(transactionId, paymentId, e)
+                else -> handleError(transactionId, paymentId, e)
+            }
+            result = false
+        }
+        requestLatency.record((now() - paymentStartedAt).toDouble())
         return result
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-13
+payment.accounts=acc-22
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
## Настройки аккаунта:
1. Число одновременно исполняющихся задач - 20'000.
2. Максимальное число проксируемых запросов в секунду - 1100.
3. Среднее время исполнения запроса - 1.6 секунд.

## Условия теста:
1. Число запросов в секунду - 100.
2. Максимальное время исполнения запроса - 1.5 секунд.

## Резульаты до:

### Число успешных тестов:
<img width="1485" height="615" alt="image" src="https://github.com/user-attachments/assets/b68c9b09-760f-4704-b6d1-e91bbd04b0d5" />

## Решение
Заметили, что среднее время исполнения запроса больше, чем время, которое готов ждать пользователь. Решили первым делам проверить графики квантилей, а также время исполнения запросов. Видно, что есть запросы, которые исполняются сильно дольше, порой значения доходят до 6 секунд. Также заметили, что теперь нет времени на ретраи, поэтому убрали их. Единственная возможность - это использовать hedged запросы. Думали какое значение выбрать для второго запроса - через сколько после первого стратовать. Решили, что оптимальнее будет выбрать значение поменьше и использовать заголовок x-idempotency-key. Это позволит нам уложится в максимальное время ожидания от клиента.

## Результаты после:

### Число успешных тестов
<img width="1480" height="691" alt="image" src="https://github.com/user-attachments/assets/0277e44e-0303-4a94-9a0c-1c5224450bbc" />


### Выручка
<img width="1485" height="631" alt="image" src="https://github.com/user-attachments/assets/66959fb9-7d69-47c7-9c20-4da9941c304a" />


### Входящий и исходящий rps
<img width="1485" height="615" alt="image" src="https://github.com/user-attachments/assets/c5d98072-b4a9-4f67-a74c-c98cc3c2ca73" />

### Число hedged запросов
<img width="1485" height="615" alt="image" src="https://github.com/user-attachments/assets/6a47fa6f-bf0b-48b1-a565-9203401a4a2c" />